### PR TITLE
Fix regex separator bug in ArrayTextInput

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ De dokumentmallar som Gerda erbjuder är en utökning av de dokumentmallar som d
 
 OBS! När en mall ändras så är det viktigt att se till att alla HTML-input har rätt `name`-attribut som matchar det som förväntas i schemat.
 
-För att smidigt kunna kunna skicka data i form av Arrayer, använd `ArrayTextInput.svelte`, som wrappar lite logik för att hantera arrayer i formuläret.
+För att smidigt kunna kunna skicka data i form av Arrayer, använd `ArrayTextInput.svelte`, som wrappar lite logik för att hantera arrayer i formuläret. De olika elementen separeras med radbrytning (`\n`).
 
 ## Development
 

--- a/src/lib/components/ArrayTextInput.svelte
+++ b/src/lib/components/ArrayTextInput.svelte
@@ -7,7 +7,6 @@
 		value: string[] | null | undefined;
 		label?: string;
 		placeholder?: string;
-		separator: string;
 		explanation?: string;
 		errors?: string[];
 		class?: string;
@@ -18,7 +17,6 @@
 		value = $bindable([]),
 		label,
 		placeholder,
-		separator,
 		explanation,
 		errors,
 		class: clazz
@@ -27,31 +25,12 @@
 	let textareaElement: HTMLTextAreaElement | undefined = $state();
 	let internalString = $state('');
 
-	const getRegex = () => {
-		const escaped = separator.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-		return new RegExp(`[${escaped}\\n]`);
-	};
-
-	$effect(() => {
-		const joined = (value ?? []).join(`${separator} `);
-
-		const cleanInternal = internalString
-			.split(getRegex())
-			.map((s) => s.trim())
-			.filter(Boolean)
-			.join(`${separator} `);
-
-		if (joined !== cleanInternal) {
-			internalString = joined;
-		}
-	});
-
 	function handleInput(e: Event & { currentTarget: HTMLTextAreaElement }) {
 		const raw = e.currentTarget.value;
 		internalString = raw;
 
 		value = raw
-			.split(getRegex())
+			.split('\n')
 			.map((s) => s.trim())
 			.filter((s) => s !== '');
 

--- a/src/lib/components/ProposalBlock.svelte
+++ b/src/lib/components/ProposalBlock.svelte
@@ -52,12 +52,11 @@
 					name={`proposals[${i}].who`}
 					bind:value={p.who}
 					placeholder={`
-					Rosa Pantern
+Rosa Pantern
 Cookie Monster`.trim()}
 					label="Vem/Vilka"
 					class="w-full"
-					separator="\n"
-					explanation="Separera med ny rad"
+					explanation="Separera med radbrytning"
 				/>
 				{#if includeStatistics}
 					<ResizingTextInput

--- a/src/routes/create/kallelse/+page.svelte
+++ b/src/routes/create/kallelse/+page.svelte
@@ -150,9 +150,10 @@
 							name={`agenda[${i}].attachments`}
 							bind:value={agendaItem.attachments}
 							label="Bilagor (semikolon-separerat)"
-							placeholder="länk1.pdf; länk2.pdf"
-							separator=";"
-							explanation="Separera länkar med semikolon"
+							placeholder={`
+https://minio.dsek.se/...
+https://minio.dsek.se/...`.trim()}
+							explanation="Separera länkar med radbrytning"
 						/>
 					</div>
 				</div>

--- a/src/routes/create/kravprofil/+page.svelte
+++ b/src/routes/create/kravprofil/+page.svelte
@@ -38,7 +38,6 @@
 	explanation="Olika krav separeras med radbrytning"
 	placeholder="Ledarskapsförmåga..."
 	bind:value={formState.requirements}
-	separator="\n"
 />
 
 <ArrayTextInput
@@ -47,5 +46,4 @@
 	explanation="Olika meriter separeras med radbrytning"
 	placeholder="Tidigare erfarenhet av..."
 	bind:value={formState.merits}
-	separator="\n"
 />


### PR DESCRIPTION
If the input contained an `n`, then it would split on that when the separator was newline `\n`. This simplifies the ArrayTextInput to only ever do newline splits